### PR TITLE
anton's minor fix

### DIFF
--- a/test_vs.glsl
+++ b/test_vs.glsl
@@ -10,3 +10,4 @@ out vec3 colour;
 void main() {
 	colour = vertex_colour;
 	gl_Position = proj * view * vec4 (vertex_position, 1.0);
+}


### PR DESCRIPTION
The program compiles fine for me without errors. I used GCC on the command line and compiled like this:

`g++ Main.cpp maths_funcs.cpp gl_utils.cpp ../gfx_expmts/common/src/GL/glew.c -I ../gfx_expmts/common/include/ -lGL -lglfw -lm`

* Compile in C++ mode
* Compile the 3 .cpp source files.
* Link against the GLEW library (i just compiled a copy of glew.c here that I had in another folder)
* Include the path to `GL/glew.h` so it can find the header.
* Link OpenGL (this is OpenGL32.lib on Windows)
* Link GLFW3

This should all work in visual studio as per the video I did. So I presume it's probably a fiddly thing with paths to libraries or headers.

The program did not run, however. The console output reported:

```
Renderer: GeForce GTX 1080 Ti/PCIe/SSE2
OpenGL version supported 4.1.0 NVIDIA 390.138
ERROR: GL shader index 1 did not compile
shader info log for GL index 1:
(0) : error C0000: syntax error, unexpected $end at token "<EOF>"
```

So I checked the shaders (I think shader index 1 is the fragment shader here) and found that one was missing a closing `}` for `main()` - hence the "EOF" end of file error.

Then it ran as pictured.

![Screenshot_2020-08-21_11-32-45](https://user-images.githubusercontent.com/1935602/90881430-17b27580-e3a2-11ea-9743-d700167bf30c.png)
